### PR TITLE
Add a19 authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg/
 tmp/
 vendor/cache/*.gem
 tmp/rspec_guard_result
+coverage/

--- a/lib/roqua/healthy/a19/fetcher.rb
+++ b/lib/roqua/healthy/a19/fetcher.rb
@@ -27,7 +27,7 @@ module Roqua
         def mirth_response
           Net::HTTP.start(remote_url.host, remote_url.port, use_ssl: use_ssl?) do |http|
             request = Net::HTTP::Post.new(remote_url.path)
-            request.basic_auth(@client.a19_username, @client.a19_password) if @client.use_basic_auth?
+            request.basic_auth(@client.a19_username, @client.a19_password)
             request.set_form_data(mirth_params)
             http.request request
           end

--- a/lib/roqua/healthy/a19/fetcher.rb
+++ b/lib/roqua/healthy/a19/fetcher.rb
@@ -27,6 +27,7 @@ module Roqua
         def mirth_response
           Net::HTTP.start(remote_url.host, remote_url.port, use_ssl: use_ssl?) do |http|
             request = Net::HTTP::Post.new(remote_url.path)
+            request.basic_auth(@client.a19_username, @client.a19_password) if @client.use_basic_auth?
             request.set_form_data(mirth_params)
             http.request request
           end
@@ -36,6 +37,8 @@ module Roqua
           raise ::Roqua::Healthy::HostUnreachable, error.message
         rescue Errno::ECONNREFUSED => error
           raise ::Roqua::Healthy::ConnectionRefused, error.message
+        rescue Net::HTTPUnauthorized => error
+          raise ::Roqua::Healthy::AuthenticationFailure, error.message
         end
 
         private

--- a/lib/roqua/healthy/client.rb
+++ b/lib/roqua/healthy/client.rb
@@ -21,7 +21,6 @@ module Roqua
         Vault.address = ENV["VAULT_ADDR"]
         Vault.token = ENV["VAULT_TOKEN"]
         Vault.with_retries(Vault::HTTPConnectionError) do
-          # Vault.logical.read("secret/medo/#{::Rails.env}/a19_basic_auth").data
           Vault.logical.read("secret/medo/#{ENV['RAILS_ENV']}/a19_basic_auth").data
         end
       end

--- a/lib/roqua/healthy/client.rb
+++ b/lib/roqua/healthy/client.rb
@@ -10,16 +10,20 @@ module Roqua
 
       def initialize(options = {})
         @a19_endpoint = options[:a19_endpoint]
-        @a19_username = options[:a19_username]
-        @a19_password = options[:a19_password]
+        @a19_username, @a19_password = vault_data.values_at(:username, :password)
       end
 
       def a19_endpoint
         @a19_endpoint || Roqua::Healthy.a19_endpoint
       end
 
-      def use_basic_auth?
-        @a19_username.present? && @a19_password.present?
+      def vault_data
+        Vault.address = ENV["VAULT_ADDR"]
+        Vault.token = ENV["VAULT_TOKEN"]
+        Vault.with_retries(Vault::HTTPConnectionError) do
+          # Vault.logical.read("secret/medo/#{::Rails.env}/a19_basic_auth").data
+          Vault.logical.read("secret/medo/#{ENV['RAILS_ENV']}/a19_basic_auth").data
+        end
       end
 
       def fetch_a19(patient_id)

--- a/lib/roqua/healthy/client.rb
+++ b/lib/roqua/healthy/client.rb
@@ -5,13 +5,21 @@ module Roqua
       include ::Roqua::Support::Instrumentation
 
       attr_accessor :a19_endpoint
+      attr_accessor :a19_username
+      attr_accessor :a19_password
 
       def initialize(options = {})
         @a19_endpoint = options[:a19_endpoint]
+        @a19_username = options[:a19_username]
+        @a19_password = options[:a19_password]
       end
 
       def a19_endpoint
         @a19_endpoint || Roqua::Healthy.a19_endpoint
+      end
+
+      def use_basic_auth?
+        @a19_username.present? && @a19_password.present?
       end
 
       def fetch_a19(patient_id)

--- a/roqua-healthy.gemspec
+++ b/roqua-healthy.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activesupport', '>= 3.2', '< 6'
   gem.add_dependency 'addressable', '~> 2.3'
   gem.add_dependency 'roqua-support', '~> 0.1.22'
+  gem.add_dependency 'vault', '~> 0.1'
 
   gem.add_development_dependency 'bundler', '~> 1.0'
   gem.add_development_dependency 'rake', '~> 10.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,19 @@ LOG_FILE = StringIO.new
 Roqua.logger = Logger.new(LOG_FILE)
 
 RSpec.configure do |config|
+  config.before(:each) do
+    # Simulate Vault usage
+    ENV['RAILS_ENV'] = 'test'
+    allow_any_instance_of(Vault::Logical).to receive(:read).with("secret/medo/test/a19_basic_auth").and_return(
+      OpenStruct.new(
+        data: {
+          username: 'foo',
+          password: 'bar'
+        }
+      )
+    )
+  end
+
   config.after(:suite) do
     if ENV["DEBUG"]
       LOG_FILE.rewind

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ SimpleCov.start
 require 'rspec'
 
 require 'webmock/rspec'
+require 'vault'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 def stub_mirth(patient_id = '123')
-  stub_request(:post, Roqua::Healthy.a19_endpoint)
+  stub_request(:post, "http://foo:bar@a19%5Fendpoint.dev/")
     .with(body: {application: 'healthy', method: 'A19', patient_id: patient_id})
 end
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 def stub_mirth(patient_id = '123')
-  stub_request(:post, "http://foo:bar@a19%5Fendpoint.dev/")
+  stub_request(:post, "http://foo:bar@10.220.0.101:60101/")
     .with(body: {application: 'healthy', method: 'A19', patient_id: patient_id})
 end
 

--- a/spec/unit/a19/fetcher_spec.rb
+++ b/spec/unit/a19/fetcher_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe Roqua::Healthy::A19::Fetcher do
-  let(:client) { Roqua::Healthy::Client.new(a19_endpoint: 'http://a19_endpoint.dev') }
+  let(:client) { Roqua::Healthy::Client.new }
 
   subject { Roqua::Healthy::A19::Fetcher.new("123", client) }
 

--- a/spec/unit/a19/fetcher_spec.rb
+++ b/spec/unit/a19/fetcher_spec.rb
@@ -2,9 +2,21 @@
 require 'spec_helper'
 
 describe Roqua::Healthy::A19::Fetcher do
-  let(:client) { Roqua::Healthy::Client.new }
+  let(:client) { Roqua::Healthy::Client.new(a19_endpoint: 'http://a19_endpoint.dev') }
 
   subject { Roqua::Healthy::A19::Fetcher.new("123", client) }
+
+  before do
+    ENV['RAILS_ENV'] = 'test'
+    allow_any_instance_of(Vault::Logical).to receive(:read).with("secret/medo/test/a19_basic_auth").and_return(
+      OpenStruct.new(
+        data: {
+          username: 'foo',
+          password: 'bar'
+        }
+      )
+    )
+  end
 
   it 'succeeds when upstream returns XML' do
     stub_mirth_response("<HL7Message></HL7Message>")

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -2,6 +2,18 @@
 require 'spec_helper'
 
 describe Roqua::Healthy::Client do
+  before do
+    ENV['RAILS_ENV'] = 'test'
+    allow_any_instance_of(Vault::Logical).to receive(:read).with("secret/medo/test/a19_basic_auth").and_return(
+      OpenStruct.new(
+        data: {
+          username: 'foo',
+          password: 'bar'
+        }
+      )
+    )
+  end
+
   context 'fully configured client' do
     subject { Roqua::Healthy::Client.new(a19_endpoint: 'http://a19_endpoint.dev') }
 


### PR DESCRIPTION
When fetching A19 data from medo, use the credentials stored in Vault for http basic authentication on the medo side.